### PR TITLE
Execute SQL task as a psql command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,63 @@ Flags:
 
 Use a valid YAML file to describe tasks.
 
+### Tasks declaration
+
+* `tasks`: a list of tasks to run
+  - `id` (required)
+  - `command` (required): will be executed
+  - `name`: attach a name or description to a task
+  - `type`: defines the execution context 
+    + `sh` (default)
+    + `psql`: needs PostgreSQL `psql` client to be installed
+  - `uri`: connection string used by `psql`'s database option (`-d`)
+  - `connection`: connection name as described below
+
 ```yaml
 tasks:
   - id: 1
     command: echo test
+  - id: 2
+    type: psql
+    name: run this statement
+    command: SELECT user;
+    uri: postgresql://localhost
+```
+
+> All PostgreSQL environment variables can be used in place of `uri` as it used
+> `psql` client.
+
+### Named connections
+
+* `connections`: declares named connections used by tasks
+  * `name`: connection name
+  * `uri`: connection string used by `psql`'s database option (`-d`)
+
+```yaml
+connections:
+  - name: db
+    uri: postgresql://remote
+  
+tasks:
+  - id: 1
+    type: psql
+    command: \conninfo
+    connection: db 
+``` 
+
+### Parallelism
+
+* `workers`: declares number of workers
+  - explicit argument passed to command takes precedence
+  - limited by the number of logical CPUs usable by the main process
+
+```yaml
+workers: 1
+
+# perform the following tasks sequentially
+tasks:
+  - id: 1
+    command: echo foo
+  - id: 2
+    command: echo bar
 ```

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -45,6 +46,24 @@ tasks:
 
 	assert.Equal(t, config.MaxWorkers, 4)
 	assert.Equal(t, config.Tasks[0].ID, 1)
+}
+
+func TestConfigFromYAMLWithConnectionOnTask(t *testing.T) {
+	cnx := "postgresql://postgres:secret@localhost:5432/postgres"
+	yamlConfig := `
+tasks:
+  - id: 1
+    name: use predefined db name
+    type: psql
+    command: SELECT 1
+    connection: "%s"
+`
+	config, err := NewConfigBuilder().
+		WithYAML(fmt.Sprintf(yamlConfig, cnx)).
+		Build()
+
+	assert.Equal(t, err, nil)
+	assert.Equal(t, config.Tasks[0].Connection, cnx)
 }
 
 func TestConfigWithMaxWorkersOverrided(t *testing.T) {

--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type Connections []Connection
+
+type Connection struct {
+	Name string `yaml:"name"`
+	URI  string `yaml:"uri"`
+}
+
+func (c Connections) GetURIByName(name string) (string, error) {
+	for _, connection := range c {
+		if connection.Name == name {
+			return connection.URI, nil
+		}
+	}
+	return "", fmt.Errorf("connection not found for name %s", name)
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectionURIbyName(t *testing.T) {
+	var c Connections
+	given := "postgresql://localhost"
+	c = append(c, Connection{
+		Name: "db",
+		URI:  given,
+	})
+	uri, _ := c.GetURIByName("db")
+
+	assert.Equal(t, uri, given)
+}

--- a/task.go
+++ b/task.go
@@ -11,6 +11,19 @@ const (
 	Succeeded
 )
 
+type Connection struct {
+	Name string `yaml:"name"`
+	URI  string `yaml:"uri"`
+}
+
+type Task struct {
+	ID         int    `yaml:"id"`
+	Type       string `yaml:"type,omitempty"`
+	Name       string `yaml:"name,omitempty"`
+	Command    string `yaml:"command"`
+	Connection string `yaml:"connection,omitempty"`
+}
+
 type TaskResult struct {
 	ID        int
 	StartTime time.Time
@@ -20,15 +33,17 @@ type TaskResult struct {
 	Message   string
 }
 
-type Task struct {
-	ID      int    `yaml:"id"`
-	Command string `yaml:"command"`
-}
-
 func (t Task) Run(ctx context.Context) TaskResult {
+	var cmd *exec.Cmd
+
 	startTime := time.Now()
 
-	cmd := exec.Command("sh", "-c", t.Command)
+	switch t.Type {
+	case "psql":
+		cmd = exec.Command("psql", "-d", t.Connection, "-c", t.Command)
+	default:
+		cmd = exec.Command("sh", "-c", t.Command)
+	}
 
 	output, err := cmd.CombinedOutput()
 	endTime := time.Now()

--- a/task.go
+++ b/task.go
@@ -11,16 +11,12 @@ const (
 	Succeeded
 )
 
-type Connection struct {
-	Name string `yaml:"name"`
-	URI  string `yaml:"uri"`
-}
-
 type Task struct {
 	ID         int    `yaml:"id"`
 	Type       string `yaml:"type,omitempty"`
 	Name       string `yaml:"name,omitempty"`
 	Command    string `yaml:"command"`
+	URI        string `yaml:"uri,omitempty"`
 	Connection string `yaml:"connection,omitempty"`
 }
 
@@ -30,7 +26,8 @@ type TaskResult struct {
 	EndTime   time.Time
 	Elapsed   time.Duration
 	Status    int
-	Message   string
+	Output    string
+	Error     string
 }
 
 func (t Task) Run(ctx context.Context) TaskResult {
@@ -40,7 +37,7 @@ func (t Task) Run(ctx context.Context) TaskResult {
 
 	switch t.Type {
 	case "psql":
-		cmd = exec.Command("psql", "-d", t.Connection, "-c", t.Command)
+		cmd = exec.Command("psql", "-d", t.URI, "-c", t.Command)
 	default:
 		cmd = exec.Command("sh", "-c", t.Command)
 	}
@@ -54,12 +51,12 @@ func (t Task) Run(ctx context.Context) TaskResult {
 		EndTime:   endTime,
 		Elapsed:   endTime.Sub(startTime),
 		Status:    Succeeded,
-		Message:   string(output),
+		Output:    string(output),
 	}
 
 	if err != nil {
 		tr.Status = Failed
-		tr.Message = err.Error()
+		tr.Error = err.Error()
 	}
 
 	return tr

--- a/task_test.go
+++ b/task_test.go
@@ -24,7 +24,7 @@ func TestShellTask(t *testing.T) {
 	result := task.Run(context.Background())
 
 	assert.Equal(t, result.Status, Succeeded)
-	assert.Contains(t, result.Message, "test")
+	assert.Contains(t, result.Output, "test")
 }
 
 func TestShellTaskWithError(t *testing.T) {
@@ -39,14 +39,26 @@ func TestShellTaskWithError(t *testing.T) {
 
 func TestPsqlTask(t *testing.T) {
 	task := &Task{
-		ID:         1,
-		Name:       "Execute SQL statement",
-		Type:       "psql",
-		Command:    "CREATE TEMPORARY TABLE foo (bar smallint);",
-		Connection: "postgresql://postgres:secret@localhost:5432/postgres",
+		ID:      1,
+		Type:    "psql",
+		Command: "CREATE TEMPORARY TABLE foo (bar smallint);",
+		URI:     "postgresql://postgres:secret@localhost:5432/postgres",
 	}
 	result := task.Run(context.Background())
 
 	assert.Equal(t, result.Status, Succeeded)
-	assert.Contains(t, result.Message, "CREATE TABLE")
+	assert.Contains(t, result.Output, "CREATE TABLE")
+}
+
+func TestPsqlTaskWihoutURI(t *testing.T) {
+	task := &Task{
+		ID:      1,
+		Name:    "should connect to default socket",
+		Type:    "psql",
+		Command: "SELECT test",
+	}
+	result := task.Run(context.Background())
+
+	assert.NotEqual(t, result.Status, Succeeded)
+	assert.Contains(t, result.Output, "test")
 }

--- a/task_test.go
+++ b/task_test.go
@@ -16,7 +16,7 @@ func TestCreateTask(t *testing.T) {
 	assert.Equal(t, task.ID, 1)
 }
 
-func TestTaskShouldSucceed(t *testing.T) {
+func TestShellTask(t *testing.T) {
 	task := &Task{
 		ID:      1,
 		Command: "echo test",
@@ -24,10 +24,10 @@ func TestTaskShouldSucceed(t *testing.T) {
 	result := task.Run(context.Background())
 
 	assert.Equal(t, result.Status, Succeeded)
-	assert.Equal(t, result.Message, "test\n")
+	assert.Contains(t, result.Message, "test")
 }
 
-func TestTaskShouldFail(t *testing.T) {
+func TestShellTaskWithError(t *testing.T) {
 	task := &Task{
 		ID:      1,
 		Command: "false",
@@ -35,4 +35,18 @@ func TestTaskShouldFail(t *testing.T) {
 	result := task.Run(context.Background())
 
 	assert.Equal(t, result.Status, Failed)
+}
+
+func TestPsqlTask(t *testing.T) {
+	task := &Task{
+		ID:         1,
+		Name:       "Execute SQL statement",
+		Type:       "psql",
+		Command:    "CREATE TEMPORARY TABLE foo (bar smallint);",
+		Connection: "postgresql://postgres:secret@localhost:5432/postgres",
+	}
+	result := task.Run(context.Background())
+
+	assert.Equal(t, result.Status, Succeeded)
+	assert.Contains(t, result.Message, "CREATE TABLE")
 }


### PR DESCRIPTION
This PR implements "psql" task type

* uses URI or named connection to perform PostgreSQL remote connection
* adds usage examples in README