### PR TITLE
Add internal QueryID

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -69,9 +69,10 @@ func (c *Config) FinalizeTasks() ([]models.Task, error) {
 				return nil, err
 			}
 
-			for _, query := range parser.Parse() {
+			for queryId, query := range parser.Parse() {
 				finalTasks = append(finalTasks, models.Task{
 					ID:      t.ID,
+					QueryID: queryId,
 					Type:    t.Type,
 					Name:    fmt.Sprintf("Query loaded from %s", t.File),
 					Command: query,

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -209,7 +209,7 @@ func TestConfigLoadTasksFromFile(t *testing.T) {
 	assert.Equal(t, "SELECT 1;", config.Tasks[0].Command)
 	assert.Equal(t, "postgresql://localhost", config.Tasks[0].URI)
 
-	// Each loaded task must have a unique query ID
+	// Each loaded task must have an unique query ID
 	assert.Equal(t, 0, config.Tasks[0].QueryID)
 	assert.Equal(t, 1, config.Tasks[1].QueryID)
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -187,7 +187,7 @@ tasks:
 
 func TestConfigLoadTasksFromFile(t *testing.T) {
 	sqlFilename := "queries_*.sql"
-	sqlContent := "SELECT 1;"
+	sqlContent := "SELECT 1; SELECT 2;"
 	tempFile, _ := os.CreateTemp("", sqlFilename)
 
 	defer tempFile.Close()
@@ -204,10 +204,14 @@ func TestConfigLoadTasksFromFile(t *testing.T) {
 		}).
 		Build()
 
-	// File task must be replaced by Command task loaded from SQL file
+	// File task must be replaced by Command tasks loaded from SQL file
 	assert.Equal(t, 1, config.Tasks[0].ID)
 	assert.Equal(t, "SELECT 1;", config.Tasks[0].Command)
 	assert.Equal(t, "postgresql://localhost", config.Tasks[0].URI)
+
+	// Each loaded task must have a unique query ID
+	assert.Equal(t, 0, config.Tasks[0].QueryID)
+	assert.Equal(t, 1, config.Tasks[1].QueryID)
 }
 
 func TestConfigWithDependencies(t *testing.T) {

--- a/src/dispatcher/dispatcher_test.go
+++ b/src/dispatcher/dispatcher_test.go
@@ -17,10 +17,7 @@ func TestDispatcherAddTask(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	status, ok := dispatcher.GetStatus(1)
-	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, status)
-	}
+	assert.Equal(t, Succeeded, dispatcher.GetStatus(1))
 }
 
 func TestDispatcherDependentTaskNeverExecuted(t *testing.T) {
@@ -36,15 +33,8 @@ func TestDispatcherDependentTaskNeverExecuted(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	status, ok := dispatcher.GetStatus(1)
-	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Failed, status)
-	}
-
-	status, ok = dispatcher.GetStatus(2)
-	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Interrupted, status)
-	}
+	assert.Equal(t, Failed, dispatcher.GetStatus(1))
+	assert.Equal(t, Interrupted, dispatcher.GetStatus(2))
 }
 
 func TestDispatcherDependentTaskGetSucceeded(t *testing.T) {
@@ -60,15 +50,8 @@ func TestDispatcherDependentTaskGetSucceeded(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	status, ok := dispatcher.GetStatus(1)
-	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, status)
-	}
-
-	status, ok = dispatcher.GetStatus(2)
-	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, status)
-	}
+	assert.Equal(t, Succeeded, dispatcher.GetStatus(1))
+	assert.Equal(t, Succeeded, dispatcher.GetStatus(2))
 }
 
 func TestDispatcherStatusOfFileTaskMustSummarizeLoadedTaskStatus(t *testing.T) {
@@ -85,6 +68,5 @@ func TestDispatcherStatusOfFileTaskMustSummarizeLoadedTaskStatus(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	status, _ := dispatcher.GetStatus(1)
-	assert.Equal(t, Failed, status)
+	assert.Equal(t, Failed, dispatcher.GetStatus(1))
 }

--- a/src/dispatcher/dispatcher_test.go
+++ b/src/dispatcher/dispatcher_test.go
@@ -17,9 +17,9 @@ func TestDispatcherAddTask(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	result, ok := dispatcher.GetResult(1)
+	status, ok := dispatcher.GetStatus(1)
 	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, result.Status)
+		assert.Equal(t, Succeeded, status)
 	}
 }
 
@@ -36,14 +36,14 @@ func TestDispatcherDependentTaskNeverExecuted(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	result, ok := dispatcher.GetResult(1)
+	status, ok := dispatcher.GetStatus(1)
 	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Failed, result.Status)
+		assert.Equal(t, Failed, status)
 	}
 
-	result, ok = dispatcher.GetResult(2)
+	status, ok = dispatcher.GetStatus(2)
 	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Interrupted, result.Status)
+		assert.Equal(t, Interrupted, status)
 	}
 }
 
@@ -60,13 +60,31 @@ func TestDispatcherDependentTaskGetSucceeded(t *testing.T) {
 	})
 	dispatcher.Wait()
 
-	result, ok := dispatcher.GetResult(1)
+	status, ok := dispatcher.GetStatus(1)
 	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, result.Status)
+		assert.Equal(t, Succeeded, status)
 	}
 
-	result, ok = dispatcher.GetResult(2)
+	status, ok = dispatcher.GetStatus(2)
 	if assert.Equal(t, true, ok) {
-		assert.Equal(t, Succeeded, result.Status)
+		assert.Equal(t, Succeeded, status)
 	}
+}
+
+func TestDispatcherStatusOfFileTaskMustSummarizeLoadedTaskStatus(t *testing.T) {
+	dispatcher := NewDispatcher(context.Background(), 1, 2)
+	dispatcher.Add(Task{
+		ID:      1,
+		QueryID: 0,
+		Command: "false",
+	})
+	dispatcher.Add(Task{
+		ID:      1,
+		QueryID: 1,
+		Command: "true",
+	})
+	dispatcher.Wait()
+
+	status, _ := dispatcher.GetStatus(1)
+	assert.Equal(t, Failed, status)
 }

--- a/src/dispatcher/dispatchermap.go
+++ b/src/dispatcher/dispatchermap.go
@@ -1,0 +1,34 @@
+package dispatcher
+
+import (
+	"sync"
+
+	"github.com/fljdin/dispatch/src/models"
+)
+
+type DispatcherMap struct {
+	completed sync.Map
+}
+
+func (dm *DispatcherMap) Load(key int) int {
+	status, ok := dm.completed.Load(key)
+
+	if !ok {
+		return models.Waiting
+	}
+
+	return status.(int)
+}
+
+func (dm *DispatcherMap) Store(key int, newStatus int) {
+	var status int
+	currentStatus := dm.Load(key)
+
+	if currentStatus > newStatus {
+		status = currentStatus
+	} else {
+		status = newStatus
+	}
+
+	dm.completed.Store(key, status)
+}

--- a/src/dispatcher/worker.go
+++ b/src/dispatcher/worker.go
@@ -29,15 +29,14 @@ func (w *Worker) Start() {
 			var status = models.Waiting
 
 			for _, id := range task.Depends {
-				completed, exists := w.dispatcher.completed.Load(id)
+				completed := w.dispatcher.completed.Load(id)
 
-				if !exists {
-					// dependency has not been completed yet
+				if completed == models.Waiting {
 					depends = append(depends, id)
 					continue
 				}
 
-				if completed.(int) >= models.Failed {
+				if completed >= models.Failed {
 					status = models.Interrupted
 				}
 			}

--- a/src/dispatcher/worker.go
+++ b/src/dispatcher/worker.go
@@ -29,7 +29,7 @@ func (w *Worker) Start() {
 			var status = models.Waiting
 
 			for _, id := range task.Depends {
-				dependency, exists := w.dispatcher.completed.Load(id)
+				completed, exists := w.dispatcher.completed.Load(id)
 
 				if !exists {
 					// dependency has not been completed yet
@@ -37,7 +37,7 @@ func (w *Worker) Start() {
 					continue
 				}
 
-				if dependency.(models.TaskResult).Status >= models.Failed {
+				if completed.(int) >= models.Failed {
 					status = models.Interrupted
 				}
 			}
@@ -46,6 +46,7 @@ func (w *Worker) Start() {
 			if status == models.Interrupted {
 				w.dispatcher.results <- models.TaskResult{
 					ID:       task.ID,
+					QueryID:  task.QueryID,
 					WorkerID: w.ID,
 					Status:   status,
 					Elapsed:  0,

--- a/src/models/task.go
+++ b/src/models/task.go
@@ -24,6 +24,7 @@ type Task struct {
 	URI        string `yaml:"uri,omitempty"`
 	Connection string `yaml:"connection,omitempty"`
 	Depends    []int  `yaml:"depends_on,omitempty"`
+	QueryID    int
 }
 
 func (t Task) VerifyRequired() error {

--- a/src/models/task.go
+++ b/src/models/task.go
@@ -88,6 +88,7 @@ func (t Task) Run() TaskResult {
 
 	tr := TaskResult{
 		ID:        t.ID,
+		QueryID:   t.QueryID,
 		StartTime: startTime,
 		EndTime:   endTime,
 		Elapsed:   endTime.Sub(startTime),

--- a/src/models/taskresult.go
+++ b/src/models/taskresult.go
@@ -4,6 +4,7 @@ import "time"
 
 type TaskResult struct {
 	ID        int
+	QueryID   int
 	WorkerID  int
 	StartTime time.Time
 	EndTime   time.Time


### PR DESCRIPTION
This PR introduces a QueryID (zero by default) for each task. 
This identifier is required in status resolution when task depends on a "file" task.