### PR TITLE
Parser handles dollar-quoted strings

### DIFF
--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -53,7 +53,7 @@ func (p *Parser) handleTransactions() {
 
 func (p *Parser) handleComments() {
 	// opening a comment
-	if !p.inComment() && (p.match("--") || p.match("/*")) {
+	if p.match("--", "/*") && !p.inCommentOrString() {
 		p.currentComment = p.currentChar
 	}
 

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -25,8 +25,10 @@ func TestParserHandleStrings(t *testing.T) {
 		`SELECT ';"';`,
 		`SELECT 1 ";'";`,
 		`SELECT $$;$$;`,
+		`SELECT /*'*/ 1"';";`,
 		`SELECT $tag$;$tag$;`,
 		`SELECT $tag$$tag;$tag$;`,
+		`SELECT /* $tag$ */$tag$;$tag$;`,
 	}
 
 	for i, q := range sqlContent {

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -24,11 +24,9 @@ func TestParserHandleStrings(t *testing.T) {
 	sqlContent := []string{
 		`SELECT ';"';`,
 		`SELECT 1 ";'";`,
-		`SELECT $$;$$;`,
-		`SELECT /*'*/ 1"';";`,
-		`SELECT $tag$;$tag$;`,
-		`SELECT $tag$$tag;$tag$;`,
-		`SELECT /* $tag$ */$tag$;$tag$;`,
+		"SELECT $$;$$;",
+		"SELECT $tag$;$tag$;",
+		"SELECT $tag$$tag;$tag$;",
 	}
 
 	for i, q := range sqlContent {
@@ -59,7 +57,25 @@ func TestParserHandleComments(t *testing.T) {
 	}
 }
 
-func TestParserHandleTransactionBloc(t *testing.T) {
+func TestParserHandleCommentsAndStringsMix(t *testing.T) {
+	sqlContent := []string{
+		`SELECT /*'*/ 1"';";`,
+		`SELECT $$/*$$ AS "$$;";`,
+		"SELECT 1 -- $tag$ ;\n +2;",
+		"SELECT /* $tag$ */$tag$;$tag$;",
+	}
+
+	for i, q := range sqlContent {
+		parser, _ := NewParserBuilder("psql").
+			WithContent(q).
+			Build()
+
+		queries := parser.Parse()
+		assert.Equal(t, sqlContent[i], queries[0])
+	}
+}
+
+func TestParserHandleTransactionBlock(t *testing.T) {
 	sqlContent := []string{
 		"BEGIN; SELECT 1; END;",
 		"BEGIN; SELECT 1; COMMIT;",

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -20,11 +20,13 @@ func TestParserWithSqlContent(t *testing.T) {
 	assert.Equal(t, 3, len(queries))
 }
 
-func TestParserHandleLiterals(t *testing.T) {
+func TestParserHandleStrings(t *testing.T) {
 	sqlContent := []string{
 		`SELECT ';"';`,
 		`SELECT 1 ";'";`,
 		`SELECT $$;$$;`,
+		`SELECT $tag$;$tag$;`,
+		`SELECT $tag$$tag;$tag$;`,
 	}
 
 	for i, q := range sqlContent {


### PR DESCRIPTION
This PR enhances parser capabilities.
Some complex valid queries could broke parser with dollar-quoted tag expression.

```go
func TestParserHandleLiteral(t *testing.T) {
	sqlContent := `SELECT $tag$$tag;$tag$;`

	parser, _ := NewParserBuilder("psql").
		WithContent(sqlContent).
		Build()

	queries := parser.Parse()
	assert.Equal(t, sqlContent, queries[0])
}
```
```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
```