### PR TITLE
Configure default connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ tasks:
 ### Named connections
 
 * `connections`: declares named connections used by tasks
-  * `name`: connection name
+  * `name`: connection name (`default` applied to any unattached tasks)
   * `uri`: a valid connection URI, takes precedence over following values
   * `host`: database server host or socket directory
   * `port`: database server port
@@ -151,9 +151,10 @@ tasks:
 connections:
   - name: db
     uri: postgresql://remote
-  - name: otherdb
+  - name: default
     host: localhost
-    dbname: otherdb
+    dbname: postgres
+    user: postgres
 
 tasks:
   - id: 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,15 @@ func (c *Config) ConfigureWorkers() {
 	}
 }
 
+func (c *Config) ConfigureConnections() {
+	if _, err := c.Connections.GetURIByName("default"); err != nil {
+		c.Connections = append(c.Connections, models.Connection{
+			Name: "default",
+			URI:  c.DefaultConnection.CombinedURI(),
+		})
+	}
+}
+
 func (c *Config) FinalizeTasks() ([]models.Task, error) {
 	var finalTasks []models.Task
 	var identifiers []int
@@ -58,7 +67,7 @@ func (c *Config) FinalizeTasks() ([]models.Task, error) {
 
 		// use default connection if no URI is provided
 		if t.URI == "" {
-			t.URI = c.DefaultConnection.CombinedURI()
+			t.URI, _ = c.Connections.GetURIByName("default")
 		}
 
 		// append task to final tasks

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,7 +84,7 @@ func TestConfigFromYAMLWithDefaultConnection(t *testing.T) {
 	yamlConfig := `
 connections:
   - name: default
-    uri: postgresql://?host=remote
+    host: remote
 tasks:
   - id: 1
     type: psql
@@ -115,7 +115,6 @@ tasks:
 		WithYAML(fmt.Sprintf(yamlConfig, cnx)).
 		Build()
 
-	assert.Equal(t, "db", config.Tasks[0].Connection)
 	assert.Equal(t, cnx, config.Tasks[0].URI)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,24 @@ tasks:
 	assert.Equal(t, cnx, config.Tasks[0].URI)
 }
 
+func TestConfigFromYAMLWithDefaultConnection(t *testing.T) {
+	yamlConfig := `
+connections:
+  - name: default
+    uri: postgresql://?host=remote
+tasks:
+  - id: 1
+    type: psql
+    command: SELECT 1
+`
+	config, _ := NewConfigBuilder().
+		WithYAML(yamlConfig).
+		Build()
+
+	assert.Equal(t, 1, len(config.Connections))
+	assert.Equal(t, "postgresql://?host=remote", config.Tasks[0].URI)
+}
+
 func TestConfigFromYAMLWithConnections(t *testing.T) {
 	cnx := "postgresql://postgres:secret@localhost:5432/postgres"
 	yamlConfig := `
@@ -97,7 +115,7 @@ tasks:
 		WithYAML(fmt.Sprintf(yamlConfig, cnx)).
 		Build()
 
-	assert.Equal(t, 1, len(config.Connections))
+	assert.Equal(t, "db", config.Tasks[0].Connection)
 	assert.Equal(t, cnx, config.Tasks[0].URI)
 }
 

--- a/internal/config/configbuilder.go
+++ b/internal/config/configbuilder.go
@@ -83,6 +83,7 @@ func (cb *ConfigBuilder) Build() (Config, error) {
 	}
 
 	cb.config.ConfigureWorkers()
+	cb.config.ConfigureConnections()
 	cb.config.Tasks, cb.err = cb.config.FinalizeTasks()
 
 	return cb.config, cb.err

--- a/internal/models/connection_test.go
+++ b/internal/models/connection_test.go
@@ -8,28 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConnectionURIbyName(t *testing.T) {
-	var c Connections
-	expected := "postgresql://localhost"
-	c = append(c, Connection{
-		Name: "db",
-		URI:  expected,
-	})
-	uri, _ := c.GetURIByName("db")
-
-	assert.Equal(t, expected, uri)
-}
-
-func TestConnectionURIbyNameNotFound(t *testing.T) {
-	var c Connections
-	c = append(c, Connection{
-		Name: "db",
-		URI:  "postgresql://localhost",
-	})
-	_, err := c.GetURIByName("nowhere")
-	require.Error(t, err)
-}
-
 var testConnections = []struct {
 	name       string
 	connection Connection
@@ -61,7 +39,29 @@ func TestConnectionCombinedURI(t *testing.T) {
 	}
 }
 
-func TestConnectionCombinedURIbyName(t *testing.T) {
+func TestConnectionsURIbyName(t *testing.T) {
+	var c Connections
+	expected := "postgresql://localhost"
+	c = append(c, Connection{
+		Name: "db",
+		URI:  expected,
+	})
+	uri, _ := c.GetURIByName("db")
+
+	assert.Equal(t, expected, uri)
+}
+
+func TestConnectionsURIbyNameNotFound(t *testing.T) {
+	var c Connections
+	c = append(c, Connection{
+		Name: "db",
+		URI:  "postgresql://localhost",
+	})
+	_, err := c.GetURIByName("nowhere")
+	require.Error(t, err)
+}
+
+func TestConnectionsCombinedURIbyName(t *testing.T) {
 	c := Connections{Connection{
 		Name: "db",
 		Host: "localhost",

--- a/internal/models/connection_test.go
+++ b/internal/models/connection_test.go
@@ -58,7 +58,7 @@ func TestConnectionsURIbyNameNotFound(t *testing.T) {
 		URI:  "postgresql://localhost",
 	})
 	_, err := c.GetURIByName("nowhere")
-	require.Error(t, err)
+	require.NotNil(t, err)
 }
 
 func TestConnectionsCombinedURIbyName(t *testing.T) {


### PR DESCRIPTION
A default connection can now be declared in YAML configuration file with the reserved name `default`.

If no default connection is given, an empty URI is generated as `postgresql://?` and any `psql` task relies on PostgreSQL environment variables.

This PR extends 74a8714ce184a38fbb05692e9c645a57865897f9