### PR TITLE
Allow meta command invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ dispatch run -j 2 -f statements.sql
 
 ## Query parsing
 
-An internal parser is used to load semicolon-separated queries as `psql`'s
-tasks. It provides correct detection of transaction blocks and anonymous code
+An internal parser is used to load queries as `psql`'s tasks. Theses queries are
+semicolon-separated or could be termined by a `psql` meta-command, like `\g` or `\gexec`.
+
+Parsing provides correct detection of transaction blocks and anonymous code
 blocks.
 
 ## Configuration

--- a/internal/models/command.go
+++ b/internal/models/command.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"time"
 
@@ -23,10 +24,12 @@ func (c Command) getExecCommand() *exec.Cmd {
 	case "psql":
 		cmd := exec.Command("psql", "-d", c.URI)
 
-		// use standard input to handle \g meta-commands
+		// use input pipe to handle \g meta-commands
 		textPipe, _ := cmd.StdinPipe()
-		fmt.Fprintf(textPipe, c.Text)
-		defer textPipe.Close()
+		go func() {
+			defer textPipe.Close()
+			io.WriteString(textPipe, c.Text)
+		}()
 
 		return cmd
 	default:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -194,9 +194,5 @@ func (p *Parser) Parse() []string {
 		p.handleTransactions()
 	}
 
-	if p.currentQuery.Len() > 0 {
-		commands = append(commands, p.currentQuery.String())
-	}
-
 	return commands
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -155,5 +155,9 @@ func (p *Parser) Parse() []string {
 		p.handleTransactions()
 	}
 
+	if p.currentQuery.Len() > 0 {
+		commands = append(commands, p.currentQuery.String())
+	}
+
 	return commands
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -20,17 +20,6 @@ func TestParserWithSqlContent(t *testing.T) {
 	assert.Equal(t, 3, len(queries))
 }
 
-func TestParserWithNoSeparatorEndingContent(t *testing.T) {
-	sqlContent := "SELECT 1; SELECT 2"
-
-	parser, _ := NewParserBuilder("psql").
-		WithContent(sqlContent).
-		Build()
-
-	queries := parser.Parse()
-	assert.Equal(t, 2, len(queries))
-}
-
 func TestParserHandleStrings(t *testing.T) {
 	sqlContent := []string{
 		`SELECT ';"';`,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/fljdin/dispatch/internal/parser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserWithSqlContent(t *testing.T) {
@@ -16,7 +17,6 @@ func TestParserWithSqlContent(t *testing.T) {
 		Build()
 
 	queries := parser.Parse()
-
 	assert.Equal(t, 3, len(queries))
 }
 
@@ -28,7 +28,6 @@ func TestParserWithNoSeparatorEndingContent(t *testing.T) {
 		Build()
 
 	queries := parser.Parse()
-
 	assert.Equal(t, 2, len(queries))
 }
 
@@ -118,19 +117,49 @@ func TestParserFromSqlFile(t *testing.T) {
 	parser, _ := NewParserBuilder("psql").
 		FromFile(tempFile.Name()).
 		Build()
-	queries := parser.Parse()
 
+	queries := parser.Parse()
 	assert.Equal(t, 1, len(queries))
 }
 
-func TestParserGSeparator(t *testing.T) {
-	sqlContent := "SELECT 1 \\g\n"
+func TestParserGCommand(t *testing.T) {
+	sqlContent := `SELECT 1\g
+SELECT 2\g result.txt
+SELECT 3\g (format=unaligned tuples_only)
+`
+	parser, _ := NewParserBuilder("psql").
+		WithContent(sqlContent).
+		Build()
+
+	queries := parser.Parse()
+	require.Equal(t, 3, len(queries))
+
+	assert.Equal(t, "SELECT 1\\g\n", queries[0])
+	assert.Equal(t, "SELECT 2\\g result.txt\n", queries[1])
+	assert.Equal(t, "SELECT 3\\g (format=unaligned tuples_only)\n", queries[2])
+}
+
+func TestParserCrosstabviewCommand(t *testing.T) {
+	sqlContent := `SELECT 1, 1, 1 \crosstabview
+SELECT 2, 2, 2 \crosstabview
+SELECT 3, 3, 3 \crosstabview
+`
 
 	parser, _ := NewParserBuilder("psql").
 		WithContent(sqlContent).
 		Build()
 
 	queries := parser.Parse()
+	assert.Equal(t, 3, len(queries))
+}
 
+func TestParserUnsupportedCommand(t *testing.T) {
+	sqlContent := "SELECT 1\\unsupported\nSELECT 1\\\nSELECT 1;"
+
+	parser, _ := NewParserBuilder("psql").
+		WithContent(sqlContent).
+		Build()
+
+	queries := parser.Parse()
 	assert.Equal(t, 1, len(queries))
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -20,6 +20,18 @@ func TestParserWithSqlContent(t *testing.T) {
 	assert.Equal(t, 3, len(queries))
 }
 
+func TestParserWithNoSeparatorEndingContent(t *testing.T) {
+	sqlContent := "SELECT 1; SELECT 2"
+
+	parser, _ := NewParserBuilder("psql").
+		WithContent(sqlContent).
+		Build()
+
+	queries := parser.Parse()
+
+	assert.Equal(t, 2, len(queries))
+}
+
 func TestParserHandleStrings(t *testing.T) {
 	sqlContent := []string{
 		`SELECT ';"';`,
@@ -106,6 +118,18 @@ func TestParserFromSqlFile(t *testing.T) {
 	parser, _ := NewParserBuilder("psql").
 		FromFile(tempFile.Name()).
 		Build()
+	queries := parser.Parse()
+
+	assert.Equal(t, 1, len(queries))
+}
+
+func TestParserGSeparator(t *testing.T) {
+	sqlContent := "SELECT 1 \\g\n"
+
+	parser, _ := NewParserBuilder("psql").
+		WithContent(sqlContent).
+		Build()
+
 	queries := parser.Parse()
 
 	assert.Equal(t, 1, len(queries))


### PR DESCRIPTION
This PR enhances `parser` package to handle `psql` meta-commands as ending separator.

Supported commands are:
* `\g`
* `\gdesc`
* `\gexec`
* `\gx` 
* `\crosstabview`

Closes #13 