### PR TITLE
Make a better shell parser

### DIFF
--- a/internal/parser/shparser.go
+++ b/internal/parser/shparser.go
@@ -1,25 +1,75 @@
 package parser
 
-import "strings"
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
 
 type ShParser struct {
 	content string
 }
 
-func (p *ShParser) Parse() []string {
-	lines := strings.Split(p.content, "\n")
-	commands := make([]string, 0)
+func (p *ShParser) SetContent(content string) {
+	p.content = content
+}
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			commands = append(commands, line)
+func (p *ShParser) Parse() []string {
+	var commands []string
+
+	scanner := bufio.NewScanner(strings.NewReader(p.content))
+	scanner.Split(scanShellCommands)
+
+	var command strings.Builder
+	inComment := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if len(strings.TrimSpace(line)) == 0 {
+			// skip empty lines
+			continue
 		}
+
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			// ignore comments
+			line = line[:idx]
+		}
+
+		if strings.HasSuffix(line, "\\") && !inComment {
+			// remove trailing backslash
+			line = line[:len(line)-1]
+			command.WriteString(line)
+		} else {
+			command.WriteString(line)
+			commands = append(commands, strings.TrimSpace(command.String()))
+			command.Reset()
+		}
+	}
+
+	if command.Len() > 0 {
+		// add the last command if it is not empty
+		commands = append(commands, strings.TrimSpace(command.String()))
 	}
 
 	return commands
 }
 
-func (p *ShParser) SetContent(content string) {
-	p.content = content
+func scanShellCommands(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// return the command up to the newline character
+		return i + 1, data[0:i], nil
+	}
+
+	if atEOF {
+		// if we're at EOF, return the remaining data
+		return len(data), data, nil
+	}
+
+	// request more data
+	return 0, nil, nil
 }

--- a/internal/parser/shparser_test.go
+++ b/internal/parser/shparser_test.go
@@ -3,19 +3,59 @@ package parser
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShParserWithContent(t *testing.T) {
-	shContent := `true
-false`
+	r := require.New(t)
 
+	shContent := "true\nfalse"
 	parser, _ := NewBuilder("sh").
 		WithContent(shContent).
 		Build()
 	commands := parser.Parse()
 
-	assert.Equal(t, 2, len(commands))
-	assert.Equal(t, "true", commands[0])
-	assert.Equal(t, "false", commands[1])
+	r.Equal(2, len(commands))
+	r.Equal("true", commands[0])
+	r.Equal("false", commands[1])
+}
+
+func TestShParserIgnoreEmptyLines(t *testing.T) {
+	r := require.New(t)
+
+	shContent := "\n\n\ntrue\n\n"
+	parser, _ := NewBuilder("sh").
+		WithContent(shContent).
+		Build()
+	commands := parser.Parse()
+
+	r.Equal(1, len(commands))
+	r.Equal("true", commands[0])
+}
+
+func TestShParserWithEscape(t *testing.T) {
+	r := require.New(t)
+
+	shContent := "true\\\n && false"
+	parser, _ := NewBuilder("sh").
+		WithContent(shContent).
+		Build()
+	commands := parser.Parse()
+
+	r.Equal(1, len(commands))
+	r.Equal("true && false", commands[0])
+}
+
+func TestShParserWithComment(t *testing.T) {
+	r := require.New(t)
+
+	shContent := "true # \\\n false"
+	parser, _ := NewBuilder("sh").
+		WithContent(shContent).
+		Build()
+	commands := parser.Parse()
+
+	r.Equal(2, len(commands))
+	r.Equal("true", commands[0])
+	r.Equal("false", commands[1])
 }


### PR DESCRIPTION
This PR enhances shell parser capabilities, like:

* ignore comments from lines
* ignore escaped newlines