### PR TITLE
Add cmd attribute in slog message

### DIFF
--- a/internal/config/yamltask.go
+++ b/internal/config/yamltask.go
@@ -51,6 +51,11 @@ func (t YamlTask) Normalize(env Environments) (tasks.Task, error) {
 		t.Variables = t.Variables.Inherit(env.Variables)
 	}
 
+	// use shell as default type
+	if t.Type == "" {
+		t.Type = tasks.Shell
+	}
+
 	var action tasks.Action
 
 	if !t.Loader.IsZero() {

--- a/internal/dispatcher/process.go
+++ b/internal/dispatcher/process.go
@@ -64,7 +64,7 @@ func (p *Process) run(t tasks.Task) {
 		"elapsed", report.Elapsed.Round(time.Millisecond),
 	)
 
-	slogFunc(fmt.Sprintf("task=%s action: %s", t, t.Action.String()))
+	slogFunc(fmt.Sprintf("task=%s cmd=%s action: %s", t, t.Action.Command(), t.Action.String()))
 
 	if len(report.Error) > 0 {
 		slogFunc(fmt.Sprintf("task=%s error: %s", t, report.Error))

--- a/internal/tasks/action.go
+++ b/internal/tasks/action.go
@@ -6,7 +6,11 @@ import (
 	"github.com/fljdin/dispatch/internal/status"
 )
 
-var CommandTypes = []string{"", "sh", "psql"}
+var (
+	Shell        = "sh"
+	PgSQL        = "psql"
+	CommandTypes = []string{Shell, PgSQL}
+)
 
 type Report struct {
 	Status    status.Status
@@ -20,5 +24,6 @@ type Report struct {
 type Action interface {
 	Validate() error
 	Run() (Report, []Action)
+	Command() string
 	String() string
 }

--- a/internal/tasks/command.go
+++ b/internal/tasks/command.go
@@ -21,6 +21,10 @@ func (c Command) String() string {
 	return c.Text
 }
 
+func (c Command) Command() string {
+	return c.Type
+}
+
 func (c Command) Validate() error {
 
 	if !slices.Contains(CommandTypes, c.Type) {

--- a/internal/tasks/command_test.go
+++ b/internal/tasks/command_test.go
@@ -12,7 +12,7 @@ func TestCommandBasicRun(t *testing.T) {
 	r := require.New(t)
 
 	cmd := Command{
-		Type: "sh",
+		Type: Shell,
 		Text: "echo test",
 	}
 	result, _ := cmd.Run()

--- a/internal/tasks/fileloader.go
+++ b/internal/tasks/fileloader.go
@@ -25,17 +25,17 @@ func (l FileLoader) load(input string) []string {
 }
 
 func (l FileLoader) String() string {
-	return fmt.Sprintf("execute %s with %s", l.File, l.Type)
+	return fmt.Sprintf("execute %s", l.File)
+}
+
+func (l FileLoader) Command() string {
+	return l.Type
 }
 
 func (l FileLoader) Validate() error {
 
 	if !slices.Contains(CommandTypes, l.Type) {
 		return fmt.Errorf("%s is not supported", l.Type)
-	}
-
-	if l.File != "" && l.Type == "" {
-		return fmt.Errorf("type is required with a file")
 	}
 
 	if l.File == "" {

--- a/internal/tasks/fileloader_test.go
+++ b/internal/tasks/fileloader_test.go
@@ -9,18 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileLoaderValidate(t *testing.T) {
-	r := require.New(t)
-
-	cmd := FileLoader{
-		File: "unknown.txt",
-	}
-	err := cmd.Validate()
-
-	r.NotNil(err)
-	r.Equal("type is required with a file", err.Error())
-}
-
 func TestFileLoaderRun(t *testing.T) {
 	r := require.New(t)
 
@@ -34,11 +22,11 @@ func TestFileLoaderRun(t *testing.T) {
 
 	cmd := FileLoader{
 		File: tempFile.Name(),
-		Type: "psql",
+		Type: PgSQL,
 	}
 	result, commands := cmd.Run()
 
 	r.Equal(Succeeded, result.Status)
-	r.Equal(Command{Text: "SELECT 1;", Type: "psql"}, commands[0])
-	r.Equal(Command{Text: "SELECT 2;", Type: "psql"}, commands[1])
+	r.Equal(Command{Text: "SELECT 1;", Type: PgSQL}, commands[0])
+	r.Equal(Command{Text: "SELECT 2;", Type: PgSQL}, commands[1])
 }

--- a/internal/tasks/outputloader.go
+++ b/internal/tasks/outputloader.go
@@ -33,6 +33,10 @@ func (l OutputLoader) String() string {
 	return l.Text
 }
 
+func (l OutputLoader) Command() string {
+	return l.From
+}
+
 func (l OutputLoader) Validate() error {
 
 	if l.Text == "" {

--- a/internal/tasks/outputloader_test.go
+++ b/internal/tasks/outputloader_test.go
@@ -25,8 +25,8 @@ func TestOutputLoaderWithFailedCommand(t *testing.T) {
 	r := require.New(t)
 
 	cmd := OutputLoader{
+		From: Shell,
 		Text: `echo true ; false`,
-		From: "sh",
 	}
 	result, _ := cmd.Run()
 
@@ -37,8 +37,8 @@ func TestOutputLoaderRun(t *testing.T) {
 	r := require.New(t)
 
 	cmd := OutputLoader{
+		From: Shell,
 		Text: "echo true; echo false",
-		From: "sh",
 	}
 	result, commands := cmd.Run()
 

--- a/internal/tasks/task_test.go
+++ b/internal/tasks/task_test.go
@@ -13,6 +13,7 @@ func TestCreateTask(t *testing.T) {
 	task := Task{
 		Identifier: NewId(1, 0),
 		Action: Command{
+			Type: Shell,
 			Text: "echo test",
 		},
 	}

--- a/t/expected/depends_on_loader_task.log
+++ b/t/expected/depends_on_loader_task.log
@@ -1,17 +1,17 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=2 procs=2
 2000-01-01 00:00:00 DEBUG  task=1:0 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="task #1 must load two others" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: echo -n "sleep .2\nsleep .1\n"
+2000-01-01 00:00:00 INFO   task=1:0 cmd=sh action: echo -n "sleep .2\nsleep .1\n"
 
 2000-01-01 00:00:00 INFO   task=1:0 output: sleep .2
 sleep .1
 
 2000-01-01 00:00:00 DEBUG  task=1:1 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=1:1 status=succeeded name="task #1 must load two others" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:1 action: sleep .2
+2000-01-01 00:00:00 INFO   task=1:1 cmd=sh action: sleep .2
 2000-01-01 00:00:00 DEBUG  task=1:2 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=1:2 status=succeeded name="task #1 must load two others" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:2 action: sleep .1
+2000-01-01 00:00:00 INFO   task=1:2 cmd=sh action: sleep .1
 2000-01-01 00:00:00 DEBUG  task=2:0 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=2:0 status=succeeded name="task #2 must wait for all subtask completion" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=2:0 action: true
+2000-01-01 00:00:00 INFO   task=2:0 cmd=sh action: true

--- a/t/expected/env_variables.log
+++ b/t/expected/env_variables.log
@@ -1,10 +1,10 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=3 procs=1
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="connect with default" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: \conninfo
+2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: \conninfo
 2000-01-01 00:00:00 INFO   task=1:0 output: You are connected to database "postgres" as user "postgres" on host "localhost" (address "::1") at port "5432".
 
 2000-01-01 00:00:00 INFO   task=2:0 status=succeeded name="connect with testing" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=2:0 action: show application_name;
+2000-01-01 00:00:00 INFO   task=2:0 cmd=psql action: show application_name;
 
 2000-01-01 00:00:00 INFO   task=2:0 output:  application_name 
 ------------------
@@ -13,7 +13,7 @@
 
 
 2000-01-01 00:00:00 INFO   task=3:0 status=succeeded name="print environment variables" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=3:0 action: echo "PGHOST     = $PGHOST"
+2000-01-01 00:00:00 INFO   task=3:0 cmd=sh action: echo "PGHOST     = $PGHOST"
 echo "PGDATABASE = $PGDATABASE"
 echo "PGUSER     = $PGUSER"
 echo "PGPORT     = $PGPORT"

--- a/t/expected/interrupted_task.log
+++ b/t/expected/interrupted_task.log
@@ -1,4 +1,4 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=2 procs=1
 2000-01-01 00:00:00 ERROR  task=1:0 status=failed name="task #1 must fail" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 ERROR  task=1:0 action: false
+2000-01-01 00:00:00 ERROR  task=1:0 cmd=sh action: false
 2000-01-01 00:00:00 ERROR  task=2:0 status=interrupted name="task #2 must be interrupted"

--- a/t/expected/loaded_from_sh_file.log
+++ b/t/expected/loaded_from_sh_file.log
@@ -1,12 +1,12 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch commands from a sh file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: execute commands.sh with sh
+2000-01-01 00:00:00 INFO   task=1:0 cmd=sh action: execute commands.sh
 2000-01-01 00:00:00 INFO   task=1:0 output: 2 loaded from commands.sh
 2000-01-01 00:00:00 INFO   task=1:1 status=succeeded name="dispatch commands from a sh file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:1 action: echo 1
+2000-01-01 00:00:00 INFO   task=1:1 cmd=sh action: echo 1
 2000-01-01 00:00:00 INFO   task=1:1 output: 1
 
 2000-01-01 00:00:00 INFO   task=1:2 status=succeeded name="dispatch commands from a sh file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:2 action: echo 2
+2000-01-01 00:00:00 INFO   task=1:2 cmd=sh action: echo 2
 2000-01-01 00:00:00 INFO   task=1:2 output: 2
 

--- a/t/expected/loaded_from_sql_file.log
+++ b/t/expected/loaded_from_sql_file.log
@@ -1,9 +1,9 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch queries from a sql file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: execute queries.sql with psql
+2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: execute queries.sql
 2000-01-01 00:00:00 INFO   task=1:0 output: 2 loaded from queries.sql
 2000-01-01 00:00:00 INFO   task=1:1 status=succeeded name="dispatch queries from a sql file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:1 action: SELECT 1;
+2000-01-01 00:00:00 INFO   task=1:1 cmd=psql action: SELECT 1;
 2000-01-01 00:00:00 INFO   task=1:1 output:  ?column? 
 ----------
         1
@@ -11,7 +11,7 @@
 
 
 2000-01-01 00:00:00 INFO   task=1:2 status=succeeded name="dispatch queries from a sql file" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:2 action: SELECT 2;
+2000-01-01 00:00:00 INFO   task=1:2 cmd=psql action: SELECT 2;
 2000-01-01 00:00:00 INFO   task=1:2 output:  ?column? 
 ----------
         2

--- a/t/expected/loaded_from_sql_output.log
+++ b/t/expected/loaded_from_sql_output.log
@@ -1,15 +1,15 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch queries from a sql output" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: SELECT format('echo %s', i) FROM generate_series(1, 2) AS i
+2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: SELECT format('echo %s', i) FROM generate_series(1, 2) AS i
 
 2000-01-01 00:00:00 INFO   task=1:0 output: echo 1
 echo 2
 
 2000-01-01 00:00:00 INFO   task=1:1 status=succeeded name="dispatch queries from a sql output" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:1 action: echo 1
+2000-01-01 00:00:00 INFO   task=1:1 cmd=sh action: echo 1
 2000-01-01 00:00:00 INFO   task=1:1 output: 1
 
 2000-01-01 00:00:00 INFO   task=1:2 status=succeeded name="dispatch queries from a sql output" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:2 action: echo 2
+2000-01-01 00:00:00 INFO   task=1:2 cmd=sh action: echo 2
 2000-01-01 00:00:00 INFO   task=1:2 output: 2
 

--- a/t/expected/loader_with_env.log
+++ b/t/expected/loader_with_env.log
@@ -1,6 +1,6 @@
 2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="Loader with environment variables" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:0 action: SELECT format('echo %s', current_setting('application_name'))
+2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: SELECT format('echo %s', current_setting('application_name'))
 UNION
 SELECT format('echo $PGAPPNAME')
 
@@ -8,10 +8,10 @@ SELECT format('echo $PGAPPNAME')
 echo bar
 
 2000-01-01 00:00:00 INFO   task=1:1 status=succeeded name="Loader with environment variables" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:1 action: echo $PGAPPNAME
+2000-01-01 00:00:00 INFO   task=1:1 cmd=sh action: echo $PGAPPNAME
 2000-01-01 00:00:00 INFO   task=1:1 output: foo
 
 2000-01-01 00:00:00 INFO   task=1:2 status=succeeded name="Loader with environment variables" start="2000-01-01 00:00:00" elapsed=0s
-2000-01-01 00:00:00 INFO   task=1:2 action: echo bar
+2000-01-01 00:00:00 INFO   task=1:2 cmd=sh action: echo bar
 2000-01-01 00:00:00 INFO   task=1:2 output: bar
 


### PR DESCRIPTION
* a task need a type, not an empty string
* `sh` remains the default command type
* an Action must implement `Command` to print `cmd` attribute in slog by a process