### PR TITLE
Bypass local CPU limit on remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ Usage:
   dispatch [options]
 
 Options:
-  -c, --config=FILE    configuration file
-  -h, --help           display this help and exit
-  -o, --output=FILE    redirect output to file
-  -P, --procs=PROCS    number of processes (default 1)
-  -v, --verbose        verbose mode
-      --version        show version
+  -c, --config=FILE      configuration file
+  -h, --help             display this help and exit
+  -o, --output=FILE      redirect output to file
+  -P, --procs=(+)PROCS   number of processes (default 1)
+  -v, --verbose          verbose mode
+      --version          show version
+
+The number of processes is limited to the number of CPU cores available
+locally by default. In a remote execution context, where the number of
+processes must not rely on the local machine, the sign "+" can be used to
+by-pass this limitation. For example, "dispatch -P +16" will spawn 16
+processes regardless of the number of CPU cores available locally.
 ```
 
 ## Configuration
@@ -150,10 +156,13 @@ tasks:
 
 * `procs`: declares number of processes
   - option `--procs` takes precedence
-  - limited by the number of logical CPUs usable by the main process
+* `remote`: defines the execution context
+  - `false` (default): limit to the number of CPU cores available locally
+  - `true`: no limit is applied to the number of processes
 
 ```yaml
 procs: 1
+remote: false
 
 # run the following tasks sequentially
 tasks:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fljdin/dispatch
 
-go 1.21
+go 1.23
 
 require (
 	github.com/fljdin/fragment v0.0.0-20230907113410-b8a526c9c145

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -18,12 +18,18 @@ var (
 		  dispatch [options]
 
 		Options:
-		  -c, --config=FILE    configuration file
-		  -h, --help           display this help and exit
-		  -o, --output=FILE    redirect output to file
-		  -P, --procs=PROCS    number of processes (default %d)
-		  -v, --verbose        verbose mode
-		      --version        show version
+		  -c, --config=FILE      configuration file
+		  -h, --help             display this help and exit
+		  -o, --output=FILE      redirect output to file
+		  -P, --procs=(+)PROCS   number of processes (default %d)
+		  -v, --verbose          verbose mode
+		      --version          show version
+
+		The number of processes is limited to the number of CPU cores available
+		locally by default. In a remote execution context, where the number of
+		processes must not rely on the local machine, the sign "+" can be used to
+		by-pass this limitation. For example, "dispatch -P +16" will spawn 16
+		processes regardless of the number of CPU cores available locally.
  	`)[1:], config.ProcessesDefault)
 
 	out *os.File = os.Stderr
@@ -82,7 +88,7 @@ func Dispatch(version string) {
 		os.Exit(1)
 	}
 
-	procs := config.ValidateProcs(k.Int("procs"))
+	procs := config.ValidateProcs(k.Int("procs"), k.Bool("remote"))
 	dispatcher := routines.NewLeader(procs)
 
 	for _, t := range t {
@@ -93,6 +99,7 @@ func Dispatch(version string) {
 		"loading configuration",
 		"tasks", len(t),
 		"procs", procs,
+		"remote", k.Bool("remote"),
 		"verbose", k.Bool("verbose"),
 	)
 

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/fljdin/dispatch/internal/config"
@@ -104,18 +105,12 @@ func TestLoadDefaultProcessNumber(t *testing.T) {
 	r.Equal(config.ProcessesDefault, procs)
 }
 
-func TestLoadProcessNumberBoundary(t *testing.T) {
+func TestValidateProcessNumberBoundary(t *testing.T) {
 	r := require.New(t)
-	k := koanf.New(".")
 
-	opts := config.Flags()
-	opts.Parse([]string{
-		"-c", "config.yaml",
-		"-P", "-1",
-	})
-
-	r.NoError(config.LoadFlags(k, opts))
-
-	procs := config.ValidateProcs(k.Int("procs"))
+	procs := config.ValidateProcs(-1)
 	r.Equal(config.ProcessesDefault, procs)
+
+	procs = config.ValidateProcs(64)
+	r.Equal(runtime.NumCPU(), procs)
 }

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -101,16 +101,41 @@ func TestLoadDefaultProcessNumber(t *testing.T) {
 	})
 	r.NoError(config.LoadFlags(k, opts))
 
-	procs := config.ValidateProcs(k.Int("procs"))
+	procs := config.ValidateProcs(k.Int("procs"), false)
 	r.Equal(config.ProcessesDefault, procs)
 }
 
 func TestValidateProcessNumberBoundary(t *testing.T) {
 	r := require.New(t)
 
-	procs := config.ValidateProcs(-1)
+	procs := config.ValidateProcs(-1, false)
 	r.Equal(config.ProcessesDefault, procs)
 
-	procs = config.ValidateProcs(64)
+	procs = config.ValidateProcs(64, false)
 	r.Equal(runtime.NumCPU(), procs)
+}
+
+func TestFlagRemoteFromProcessNumber(t *testing.T) {
+	r := require.New(t)
+	k := koanf.New(".")
+
+	opts := config.Flags()
+	opts.Parse([]string{
+		"-c", "config.yaml",
+		"-P", "+64",
+	})
+	r.NoError(config.LoadFlags(k, opts))
+	r.Equal(true, k.Bool("remote"))
+}
+
+func TestInvalidProcsFlag(t *testing.T) {
+	r := require.New(t)
+	k := koanf.New(".")
+
+	opts := config.Flags()
+	opts.Parse([]string{
+		"-c", "config.yaml",
+		"-P", "invalid",
+	})
+	r.Error(config.LoadFlags(k, opts))
 }

--- a/t/config/remote_execution.yaml
+++ b/t/config/remote_execution.yaml
@@ -1,0 +1,8 @@
+procs: 10
+remote: true
+output: remote_execution.log
+verbose: true
+
+tasks:
+  - id: 1
+    command: "sleep .1"

--- a/t/expected/depends_on_loader_task.log
+++ b/t/expected/depends_on_loader_task.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=2 procs=2 verbose=true
+2000-01-01 00:00:00 INFO   loading configuration tasks=2 procs=2 remote=false verbose=true
 2000-01-01 00:00:00 DEBUG  filling tasks channel idle=2
 2000-01-01 00:00:00 DEBUG  task=1:0 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="task #1 must load two others" elapsed=0s

--- a/t/expected/env_variables.log
+++ b/t/expected/env_variables.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=4 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=4 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="connect with default" elapsed=0s
 2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: \conninfo
 2000-01-01 00:00:00 INFO   task=1:0 output: You are connected to database "postgres" as user "postgres" on host "localhost" (address "::1") at port "5432".

--- a/t/expected/interrupted_task.log
+++ b/t/expected/interrupted_task.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=3 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=3 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 ERROR  task=1:0 status=failed name="task #1 must fail" elapsed=0s
 2000-01-01 00:00:00 ERROR  task=1:0 cmd=sh action: false
 2000-01-01 00:00:00 ERROR  task=2:0 status=interrupted name="task #2 must be interrupted"

--- a/t/expected/loaded_from_sh_file.log
+++ b/t/expected/loaded_from_sh_file.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch commands from a sh file" elapsed=0s
 2000-01-01 00:00:00 INFO   task=1:0 cmd=sh action: execute commands.sh
 2000-01-01 00:00:00 INFO   task=1:0 output: 2 loaded from commands.sh

--- a/t/expected/loaded_from_sql_file.log
+++ b/t/expected/loaded_from_sql_file.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch queries from a sql file" elapsed=0s
 2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: execute queries.sql
 2000-01-01 00:00:00 INFO   task=1:0 output: 2 loaded from queries.sql

--- a/t/expected/loaded_from_sql_output.log
+++ b/t/expected/loaded_from_sql_output.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="dispatch queries from a sql output" elapsed=0s
 2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: SELECT format('echo %s', i) FROM generate_series(1, 2) AS i
 

--- a/t/expected/loaded_tasks_multiple_procs.log
+++ b/t/expected/loaded_tasks_multiple_procs.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=2 verbose=true
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=2 remote=false verbose=true
 2000-01-01 00:00:00 DEBUG  filling tasks channel idle=2
 2000-01-01 00:00:00 DEBUG  task=1:0 msg="task sent to internal channel"
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="loaded task must be handled by idle process as soon as possible" elapsed=0s

--- a/t/expected/loader_with_env.log
+++ b/t/expected/loader_with_env.log
@@ -1,4 +1,4 @@
-2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 verbose=false
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=1 remote=false verbose=false
 2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="Loader with environment variables" elapsed=0s
 2000-01-01 00:00:00 INFO   task=1:0 cmd=psql action: SELECT format('echo %s', current_setting('application_name'))
 UNION

--- a/t/expected/remote_execution.log
+++ b/t/expected/remote_execution.log
@@ -1,0 +1,7 @@
+2000-01-01 00:00:00 INFO   loading configuration tasks=1 procs=10 remote=true verbose=true
+2000-01-01 00:00:00 DEBUG  filling tasks channel idle=10
+2000-01-01 00:00:00 DEBUG  task=1:0 msg="task sent to internal channel"
+2000-01-01 00:00:00 INFO   task=1:0 status=succeeded name="" elapsed=0s
+2000-01-01 00:00:00 INFO   task=1:0 cmd=sh action: sleep .1
+2000-01-01 00:00:00 DEBUG  task=1:0 start="2000-01-01 00:00:00" end="2000-01-01 00:00:00"
+2000-01-01 00:00:00 DEBUG  filling tasks channel idle=10

--- a/t/tests.bats
+++ b/t/tests.bats
@@ -65,3 +65,8 @@ function assert-diff() {
     dispatch --config config/loader_with_env.yaml
     assert-diff loader_with_env.log
 }
+
+@test "#36 do not limit CPU on remote execution" {
+    dispatch --config config/remote_execution.yaml
+    assert-diff remote_execution.log
+}


### PR DESCRIPTION
This PR introduces the `remote` option, if set on `true`, will bypass the CPU limit for remote execution

- New YAML option `remote` to switch the default behaviour
- A special `+` sign on command flag to force the remote option

```console
dispatch -c config.yml --procs +36
```

Closes #36 